### PR TITLE
Spread values for underlying gocqlx Bind

### DIFF
--- a/queryx.go
+++ b/queryx.go
@@ -84,7 +84,7 @@ func (q *Queryx) BindMap(arg map[string]interface{}) IQueryx {
 }
 
 func (q *Queryx) Bind(v ...interface{}) IQueryx {
-	queryx := q.Q.Bind(v)
+	queryx := q.Q.Bind(v...)
 
 	q.Q = queryx
 


### PR DESCRIPTION
This fixes an issue due to the wrapping of gocqlx Query.Bind() call.

See https://github.com/Guilospanck/igocqlx/issues/1 for details.