### PR TITLE
feat: get the underlying gocql session

### DIFF
--- a/sessionx.go
+++ b/sessionx.go
@@ -13,6 +13,7 @@ type ISessionx interface {
 	ExecStmt(stmt string) error
 	AwaitSchemaAgreement(ctx context.Context) error
 	Close()
+	Session() *Session
 }
 
 type Session struct {
@@ -45,6 +46,10 @@ func (s *Session) AwaitSchemaAgreement(ctx context.Context) error {
 
 func (s *Session) Close() {
 	s.S.Close()
+}
+
+func (s *Session) Session() *Session {
+	return s
 }
 
 func NewSession(session *gocql.Session) ISessionx {


### PR DESCRIPTION
When using third party libraries, like `go-migrate`, we need to access the underlying gocql session. Added the method to access the gocql.Session